### PR TITLE
Add optional SQLite text translation cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,12 @@ shards build --release
 
 A compiled binary file will be created in the `bin` directory. Installation is simply copying the generated binary.
 
+Advanced: build with SQLite text caching:
+
+```sh
+shards build --release -Dsqlite_cache
+```
+
 ```
 sudo cp bin/deepl /usr/local/bin
 ```

--- a/shard.yml
+++ b/shard.yml
@@ -18,5 +18,7 @@ dependencies:
   easyclip:
     github: kojix2/easyclip
     version: "0.1.3"
+  sqlite3:
+    github: crystal-lang/crystal-sqlite3
 
 license: MIT

--- a/spec/cache_spec.cr
+++ b/spec/cache_spec.cr
@@ -1,0 +1,77 @@
+{% if flag?(:sqlite_cache) %}
+  require "./spec_helper"
+
+  describe DeepL::Cache do
+    it "stores and looks up translation results" do
+      with_cache do |cache|
+        option = cache_option("Hello")
+        key = cache.key_for(option)
+        results = [DeepL::TextResult.new("こんにちは", "EN", 5_i64, "quality_optimized")]
+
+        cache.lookup(key).should be_nil
+        cache.store(key, results)
+
+        cached = cache.lookup(key)
+        cached.should_not be_nil
+        cached.not_nil!.should eq(results)
+      end
+    end
+
+    it "changes keys when translation-affecting options change" do
+      with_cache do |cache|
+        base = cache_option("Hello")
+
+        changes = [] of DeepL::Options
+        changed = cache_option("Hello")
+        changed.target_lang = "DE"
+        changes << changed
+        changed = cache_option("Hello")
+        changed.source_lang = "EN"
+        changes << changed
+        changed = cache_option("Hello")
+        changed.formality = "more"
+        changes << changed
+        changed = cache_option("Hello")
+        changed.context = "Greeting"
+        changes << changed
+        changed = cache_option("Hello")
+        changed.model_type = "quality_optimized"
+        changes << changed
+        changed = cache_option("Hello")
+        changed.glossary_name = "my glossary"
+        changes << changed
+
+        changes.each do |changed|
+          cache.key_for(base).should_not eq(cache.key_for(changed))
+        end
+      end
+    end
+
+    it "uses the normalized input text in cache keys" do
+      with_cache do |cache|
+        ansi = cache_option("\e[31mHello\e[0m")
+        plain = cache_option("Hello")
+
+        cache.key_for(ansi).should_not eq(cache.key_for(plain))
+        ansi.input_text = "Hello"
+        cache.key_for(ansi).should eq(cache.key_for(plain))
+      end
+    end
+  end
+
+  private def cache_option(text : String) : DeepL::Options
+    option = DeepL::Options.new
+    option.input_text = text
+    option.target_lang = "JA"
+    option
+  end
+
+  private def with_cache(&)
+    dir = File.tempname("deepl-cli-cache-spec")
+    FileUtils.mkdir_p(dir)
+    cache = DeepL::Cache.new(Path[dir] / "cache.sqlite3")
+    yield cache
+  ensure
+    FileUtils.rm_rf(dir) if dir
+  end
+{% end %}

--- a/src/deepl/cache.cr
+++ b/src/deepl/cache.cr
@@ -1,0 +1,154 @@
+{% if flag?(:sqlite_cache) %}
+  require "digest/sha256"
+  require "file_utils"
+  require "json"
+  require "sqlite3"
+  require "./options"
+
+  module DeepL
+    class Cache
+      SCHEMA_VERSION = 1
+
+      getter path : Path
+
+      def self.default_path : Path
+        if path = ENV["DEEPL_CACHE_PATH"]?
+          Path[path]
+        else
+          Path.home / ".cache/deepl-cli/cache.sqlite3"
+        end
+      end
+
+      def initialize(@path : Path = self.class.default_path)
+      end
+
+      def lookup(key : String) : Array(TextResult)?
+        with_db do |db|
+          response_json = db.query_one?(
+            "SELECT response_json FROM translation_cache WHERE cache_key = ?",
+            key,
+            as: String
+          )
+          return unless response_json
+
+          db.exec "UPDATE translation_cache SET last_used_at = ? WHERE cache_key = ?", timestamp, key
+          parse_results(response_json)
+        end
+      end
+
+      def store(key : String, results : Array(TextResult)) : Nil
+        now = timestamp
+        with_db do |db|
+          db.exec(
+            <<-SQL,
+            INSERT INTO translation_cache (cache_key, response_json, created_at, last_used_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(cache_key) DO UPDATE SET
+              response_json = excluded.response_json,
+              last_used_at = excluded.last_used_at
+            SQL
+            key,
+            results_to_json(results),
+            now,
+            now
+          )
+        end
+      end
+
+      def key_for(option : Options) : String
+        payload = JSON.build do |json|
+          json.object do
+            json.field "schema_version", SCHEMA_VERSION
+            json.field "text", option.input_text
+            json.field "target_lang", option.target_lang
+            json.field "source_lang", option.source_lang
+            json.field "formality", option.formality
+            json.field "glossary_name", option.glossary_name
+            json.field "context", option.context
+            json.field "split_sentences", option.split_sentences
+            json.field "preserve_formatting", option.preserve_formatting?
+            json.field "tag_handling", option.tag_handling
+            json.field "outline_detection", option.outline_detection?
+            json.field "non_splitting_tags", option.non_splitting_tags
+            json.field "splitting_tags", option.splitting_tags
+            json.field "ignore_tags", option.ignore_tags
+            json.field "model_type", option.model_type
+          end
+        end
+
+        Digest::SHA256.hexdigest(payload)
+      end
+
+      private def with_db(& : DB::Database -> T) : T forall T
+        FileUtils.mkdir_p(path.dirname.to_s)
+        DB.open(db_uri) do |db|
+          db.exec "PRAGMA journal_mode=WAL"
+          db.exec "PRAGMA busy_timeout=5000"
+          initialize_schema(db)
+          yield db
+        end
+      end
+
+      private def initialize_schema(db) : Nil
+        db.exec <<-SQL
+        CREATE TABLE IF NOT EXISTS translation_cache (
+          cache_key TEXT PRIMARY KEY,
+          response_json TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          last_used_at TEXT NOT NULL
+        )
+        SQL
+      end
+
+      private def db_uri : String
+        "sqlite3://#{path}"
+      end
+
+      private def timestamp : String
+        Time.utc.to_rfc3339
+      end
+
+      private def results_to_json(results : Array(TextResult)) : String
+        JSON.build do |json|
+          json.array do
+            results.each do |result|
+              json.object do
+                json.field "text", result.text
+                json.field "detected_source_language", result.detected_source_language
+                json.field "billed_characters", result.billed_characters
+                json.field "model_type_used", result.model_type_used
+              end
+            end
+          end
+        end
+      end
+
+      private def parse_results(response_json : String) : Array(TextResult)
+        JSON.parse(response_json).as_a.map do |item|
+          billed_characters = nilable_i64(item["billed_characters"]?)
+          model_type_used = nilable_string(item["model_type_used"]?)
+          TextResult.new(
+            text: item["text"].as_s,
+            detected_source_language: item["detected_source_language"].as_s,
+            billed_characters: billed_characters,
+            model_type_used: model_type_used
+          )
+        end
+      end
+
+      private def nilable_i64(value : JSON::Any?) : Int64?
+        return unless value
+        return if value.raw.nil?
+
+        value.as_i64
+      end
+
+      private def nilable_string(value : JSON::Any?) : String?
+        return unless value
+        return if value.raw.nil?
+
+        value.as_s
+      end
+    end
+  end
+{% end %}

--- a/src/deepl/cli.cr
+++ b/src/deepl/cli.cr
@@ -4,6 +4,9 @@ require "./prompt"
 require "./term_spinner"
 require "./parser"
 require "./utils"
+{% if flag?(:sqlite_cache) %}
+  require "./cache"
+{% end %}
 
 module DeepL
   class CLI
@@ -103,8 +106,50 @@ module DeepL
       end
 
       translator = DeepL::Translator.new
+      result, cache_hit = translate_text_result(translator)
 
-      result = with_spinner do
+      output = option.output_file ? IO::Memory.new : STDOUT
+
+      result.each do |result_item|
+        if option.detect_source_language?
+          STDERR.puts "[deepl-cli] Detected source language: #{result_item.detected_source_language}"
+        end
+        if option.show_billed_characters?
+          billed_characters = cache_hit ? "0 (cache hit)" : result_item.billed_characters
+          STDERR.puts "[deepl-cli] Billed characters: #{billed_characters}"
+        end
+        # if option.show_model_type && r.model_type_used
+        #   STDERR.puts "[deepl-cli] Model type used: #{r.model_type_used}"
+        # end
+        output.puts result_item.text
+      end
+      if output_file = option.output_file
+        File.open(output_file, "w") do |output_file_handle|
+          output.to_s(output_file_handle)
+        end
+        STDERR.puts "[deepl-cli] Translated text is written to #{output_file}"
+      end
+    end
+
+    private def translate_text_result(translator) : Tuple(Array(TextResult), Bool)
+      {% if flag?(:sqlite_cache) %}
+        cache = Cache.new
+        cache_key = cache.key_for(option)
+        if cached_result = cache.lookup(cache_key)
+          STDERR.puts "[deepl-cli] Translation cache hit: #{cache.path}"
+          {cached_result, true}
+        else
+          api_result = translate_text_with_api(translator)
+          cache.store(cache_key, api_result)
+          {api_result, false}
+        end
+      {% else %}
+        {translate_text_with_api(translator), false}
+      {% end %}
+    end
+
+    private def translate_text_with_api(translator) : Array(TextResult)
+      with_spinner do
         translator.translate_text(
           text: option.input_text,
           target_lang: option.target_lang,
@@ -122,27 +167,6 @@ module DeepL
           show_billed_characters: option.show_billed_characters?,
           model_type: option.model_type
         )
-      end
-
-      output = option.output_file ? IO::Memory.new : STDOUT
-
-      result.each do |result_item|
-        if option.detect_source_language?
-          STDERR.puts "[deepl-cli] Detected source language: #{result_item.detected_source_language}"
-        end
-        if option.show_billed_characters?
-          STDERR.puts "[deepl-cli] Billed characters: #{result_item.billed_characters}"
-        end
-        # if option.show_model_type && r.model_type_used
-        #   STDERR.puts "[deepl-cli] Model type used: #{r.model_type_used}"
-        # end
-        output.puts result_item.text
-      end
-      if output_file = option.output_file
-        File.open(output_file, "w") do |output_file_handle|
-          output.to_s(output_file_handle)
-        end
-        STDERR.puts "[deepl-cli] Translated text is written to #{output_file}"
       end
     end
 


### PR DESCRIPTION
- Gate cache implementation behind the `sqlite_cache` compile flag
- Add SQLite-backed lookup/store support for translated text results
- Add cache specs that only run with `-Dsqlite_cache`
- Document the advanced cache-enabled build command